### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Stories in Ready](https://badge.waffle.io/pki-io/admin.png?label=ready&title=Ready)](https://waffle.io/pki-io/admin)
 [![Build Status](https://travis-ci.org/pki-io/admin.svg?branch=master)](https://travis-ci.org/pki-io/admin)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/pki-io/admin

This was requested by a real person (user zeroXten) on waffle.io, we're not trying to spam you.