### PR TITLE
export helper and used by node show

### DIFF
--- a/runPairingKey.go
+++ b/runPairingKey.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/hex"
+	"fmt"
 	"github.com/docopt/docopt-go"
 	"github.com/pki-io/pki.io/crypto"
 )
@@ -25,8 +26,8 @@ func pairingKeyNew(argv map[string]interface{}) (err error) {
 	index.AddPairingKey(id, key, tags)
 
 	SaveIndex(fsAPI, org, index)
-	logger.Infof("Pairing ID: %s\n", id)
-	logger.Infof("Pairing key: %s\n", key)
+	fmt.Printf("Pairing ID: %s\n", id)
+	fmt.Printf("Pairing key: %s\n", key)
 	return nil
 }
 


### PR DESCRIPTION
Added export function to helpers and this is used by "node show"

     $ pki.io node show --name server1 --cert 54c8a7c0-e133-2acb-20ab-aa5ef5fdd0b0 --export export.tar.gz

Or

    $ pki.io node show --name server1 --cert 54c8a7c0-e133-2acb-20ab-aa5ef5fdd0b0 --export - | openssl aes-256-cbc -a -salt -out server1.tar.gz.enc

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pki-io/admin/48)
<!-- Reviewable:end -->
