### PR TITLE
removed golang 1.3 from travis.yml, updated README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 go:
   - 1.5.1
   - 1.4
-  - 1.3
 before_install:
   - git clone https://github.com/sstephenson/bats.git
   - cd bats

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Dependencies
 
-* [Go 1.4](http://golang.org/) or 1.3
+* [Go 1.5.1](http://golang.org/) or 1.4
 * [Git](http://git-scm.com/) 
 * [Bats](https://github.com/sstephenson/bats)
 * [fdm](https://github.com/pki-io/fdm) (just a bash script)


### PR DESCRIPTION
removed Golang 1.3 from travis.yml
Updated documentation to indicate that 1.3 is NOT supported

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pki-io/admin/131)
<!-- Reviewable:end -->
