### PR TITLE
Make use of mow.cli interceptors to init and close loggers

### DIFF
--- a/Vendors
+++ b/Vendors
@@ -1,7 +1,7 @@
 ##### CLI argument parsing #####
 
 #vendor -f "github.com/pki-io/docopt.go" -r "github.com/docopt/docopt-go" -g "checkout 854c423c810880e30b9fecdabb12d54f4a92f9bb"
-vendor -f "github.com/pki-io/mow.cli" -r "github.com/jawher/mow.cli" -g "checkout 99e76c7b8062ea7ae8c0aff76c392fa047619f1e"
+vendor -f "github.com/pki-io/mow.cli" -r "github.com/jawher/mow.cli" -g "checkout cea64dc3eb09a4a293ed0d9a14438e171e343c1a"
 
 ##### ASCII tables #####
 vendor -f "github.com/pki-io/tablewriter" -r "github.com/olekukonko/tablewriter" -g "checkout b9346ac189c55dd419f85c7ad2cd56f810bf19d6"

--- a/adminApp.go
+++ b/adminApp.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/jawher/mow.cli"
 	"github.com/olekukonko/tablewriter"
 	"os"
 )
@@ -21,7 +22,7 @@ func NewAdminApp() *AdminApp {
 
 func (app *AdminApp) Exit() {
 	logger.Flush()
-	os.Exit(0)
+	cli.Exit(0)
 }
 
 func (app *AdminApp) Fatal(err error) {
@@ -49,7 +50,7 @@ The pki.io team`
 
 	logger.Critical(err)
 	fmt.Println(congrats)
-	os.Exit(1)
+	cli.Exit(1)
 }
 
 func (app *AdminApp) NewTable() *tablewriter.Table {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,12 @@ func main() {
 	logLevel = cmd.StringOpt("l log-level", "info", "log level")
 	logging = cmd.StringOpt("logging", "", "alternative logging configuration")
 
+	cmd.Before = func() {
+		initLogging(*logLevel, *logging)
+	}
+	cmd.After= func() {
+		logger.Close()
+	}
 	cmd.Command("init", "Initialize an organization", initCmd)
 	cmd.Command("admin", "Manage organization admins", adminCmd)
 	cmd.Command("ca", "Manage X.509 Certificate Authorities", caCmd)

--- a/runAdmin.go
+++ b/runAdmin.go
@@ -20,9 +20,6 @@ func adminListCmd(cmd *cli.Cmd) {
 	params := NewAdminParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("listing admins")
 
@@ -54,9 +51,6 @@ func adminShowCmd(cmd *cli.Cmd) {
 	params.name = cmd.StringArg("NAME", "", "name of admin")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("showing admin")
 
@@ -98,9 +92,6 @@ func adminInviteCmd(cmd *cli.Cmd) {
 	params.name = cmd.StringArg("NAME", "", "name of admin")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("creating admin invite")
 
@@ -140,9 +131,6 @@ func adminNewCmd(cmd *cli.Cmd) {
 	params.inviteKey = cmd.StringOpt("invite-key", "", "invite key")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("creating new admin")
 
@@ -162,9 +150,6 @@ func adminRunCmd(cmd *cli.Cmd) {
 	params := NewAdminParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("running admin tasks")
 
@@ -190,9 +175,6 @@ func adminCompleteCmd(cmd *cli.Cmd) {
 	params.inviteKey = cmd.StringOpt("invite-key", "", "invite key")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("completing new admin")
 
@@ -217,9 +199,6 @@ func adminDeleteCmd(cmd *cli.Cmd) {
 	params.confirmDelete = cmd.StringOpt("confirm-delete", "", "reason for deleting admin")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("deleting admin")
 

--- a/runCA.go
+++ b/runCA.go
@@ -44,9 +44,6 @@ func caNewCmd(cmd *cli.Cmd) {
 	params.dnPostal = cmd.StringOpt("dn-postal", "", "PostalCode for DN scope")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("creating new CA")
 
@@ -82,9 +79,6 @@ func caListCmd(cmd *cli.Cmd) {
 	params := NewCAParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("listing CAs")
 
@@ -121,9 +115,6 @@ func caShowCmd(cmd *cli.Cmd) {
 	params.private = cmd.BoolOpt("private", false, "show/export private data")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("showing CA")
 
@@ -190,9 +181,6 @@ func caUpdateCmd(cmd *cli.Cmd) {
 	params.dnPostal = cmd.StringOpt("dn-postal", "", "PostalCode for DN scope")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("updating CA")
 
@@ -218,9 +206,6 @@ func caDeleteCmd(cmd *cli.Cmd) {
 	params.confirmDelete = cmd.StringOpt("confirm-delete", "", "reason for deleting CA")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("deleting CA")
 

--- a/runCSR.go
+++ b/runCSR.go
@@ -35,9 +35,6 @@ func csrNewCmd(cmd *cli.Cmd) {
 	params.dnPostal = cmd.StringOpt("dn-postal", "", "PostalCode for DN")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("creating new CSR")
 
@@ -71,9 +68,6 @@ func csrListCmd(cmd *cli.Cmd) {
 	params := NewCSRParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("listing CSRs")
 
@@ -108,9 +102,6 @@ func csrShowCmd(cmd *cli.Cmd) {
 	params.private = cmd.BoolOpt("private", false, "show/export private data")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("showing CSR")
 
@@ -156,9 +147,6 @@ func csrSignCmd(cmd *cli.Cmd) {
 	params.tags = cmd.StringOpt("tags", "", "comma separated list of tags")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("signing CSR")
 
@@ -200,9 +188,6 @@ func csrUpdateCmd(cmd *cli.Cmd) {
 	params.tags = cmd.StringOpt("tags", "", "comma separated list of tags")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("updating CSR")
 
@@ -226,9 +211,6 @@ func csrDeleteCmd(cmd *cli.Cmd) {
 	params.confirmDelete = cmd.StringOpt("confirm-delete", "", "reason for deleting CSR")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("deleting CSR")
 

--- a/runCert.go
+++ b/runCert.go
@@ -36,9 +36,6 @@ func certNewCmd(cmd *cli.Cmd) {
 	params.dnPostal = cmd.StringOpt("dn-postal", "", "PostalCode for DN")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("creating new certificate")
 
@@ -70,9 +67,6 @@ func certListCmd(cmd *cli.Cmd) {
 	params := NewCertParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("listing certificates")
 
@@ -107,9 +101,6 @@ func certShowCmd(cmd *cli.Cmd) {
 	params.private = cmd.BoolOpt("private", false, "show/export private data")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("showing certificate")
 
@@ -157,9 +148,6 @@ func certUpdateCmd(cmd *cli.Cmd) {
 	params.tags = cmd.StringOpt("tags", "", "comma separated list of tags")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("updating certificate")
 
@@ -183,9 +171,6 @@ func certDeleteCmd(cmd *cli.Cmd) {
 	params.confirmDelete = cmd.StringOpt("confirm-delete", "", "reason for deleting certificate")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("deleting certificate")
 

--- a/runHax0r.go
+++ b/runHax0r.go
@@ -26,9 +26,6 @@ func orgEncryptCmd(cmd *cli.Cmd) {
 	params.containerFile = cmd.StringArg("CONTAINER", "", "container output file")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 
 		if err := app.env.LoadAdminEnv(); err != nil {
@@ -65,9 +62,6 @@ func orgDecryptCmd(cmd *cli.Cmd) {
 	params.jsonFile = cmd.StringArg("JSON", "", "json output file")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 
 		if err := app.env.LoadAdminEnv(); err != nil {

--- a/runInit.go
+++ b/runInit.go
@@ -13,9 +13,6 @@ func initCmd(cmd *cli.Cmd) {
 	params.admin = cmd.StringOpt("admin", "admin", "name of admin")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("initialising new org")
 

--- a/runNode.go
+++ b/runNode.go
@@ -25,9 +25,6 @@ func nodeNewCmd(cmd *cli.Cmd) {
 	params.pairingKey = cmd.StringOpt("pairing-key", "", "pairing key")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("creating new node")
 
@@ -59,9 +56,6 @@ func nodeRunCmd(cmd *cli.Cmd) {
 	params.name = cmd.StringArg("NAME", "", "name of node")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("running node tasks")
 
@@ -86,9 +80,6 @@ func nodeCertCmd(cmd *cli.Cmd) {
 	params.private = cmd.BoolOpt("private", false, "show/export private data")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("creating node certificate")
 
@@ -109,9 +100,6 @@ func nodeListCmd(cmd *cli.Cmd) {
 	params := NewNodeParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 
 		logger.Info("listing nodes")
@@ -145,9 +133,6 @@ func nodeShowCmd(cmd *cli.Cmd) {
 	params.name = cmd.StringArg("NAME", "", "name of node")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("showing node")
 
@@ -188,9 +173,6 @@ func nodeDeleteCmd(cmd *cli.Cmd) {
 	params.confirmDelete = cmd.StringOpt("confirm-delete", "", "reason for deleting node")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("deleting node")
 		cont, err := NewNodeController(app.env)

--- a/runOrg.go
+++ b/runOrg.go
@@ -19,9 +19,6 @@ func orgListCmd(cmd *cli.Cmd) {
 	params := NewOrgParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("listing organisations")
 
@@ -53,9 +50,6 @@ func orgShowCmd(cmd *cli.Cmd) {
 	params.private = cmd.BoolOpt("private", false, "show/export private data")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("showing organisation")
 
@@ -93,9 +87,6 @@ func orgRunCmd(cmd *cli.Cmd) {
 	params := NewOrgParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("running organisation tasks")
 
@@ -118,9 +109,6 @@ func orgDeleteCmd(cmd *cli.Cmd) {
 	params.confirmDelete = cmd.StringOpt("confirm-delete", "", "reason for deleting organisation")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("deleting organisation")
 

--- a/runPairingKey.go
+++ b/runPairingKey.go
@@ -19,9 +19,6 @@ func pairingKeyNewCmd(cmd *cli.Cmd) {
 	params.tags = cmd.StringOpt("tags", "", "comma separated list of tags")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("creating new pairing key")
 
@@ -54,9 +51,6 @@ func pairingKeyListCmd(cmd *cli.Cmd) {
 	params := NewPairingKeyParams()
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("listing pairing keys")
 
@@ -90,9 +84,6 @@ func pairingKeyShowCmd(cmd *cli.Cmd) {
 	params.private = cmd.BoolOpt("private", false, "show/export private data")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("showing pairing key")
 
@@ -129,9 +120,6 @@ func pairingKeyDeleteCmd(cmd *cli.Cmd) {
 	params.confirmDelete = cmd.StringOpt("confirm-delete", "", "reason for deleting pairing key")
 
 	cmd.Action = func() {
-		initLogging(*logLevel, *logging)
-		defer logger.Close()
-
 		app := NewAdminApp()
 		logger.Info("deleting pairing key")
 


### PR DESCRIPTION
`mow.cli` added support for before and after interceptors (see jawher/mow.cli#12 and  jawher/mow.cli#15), which are a perfect match for what every command in `pkt.io/admin` was doing, mainly initialising a logger and closing it afterwards.

[The relevant section on interceptors in mow.cli's README file](https://github.com/jawher/mow.cli#interceptors)

Note however that this won't build until pki-io's fork of mow.cli is updated to at least 5a708d497f63791effeb817ab7501e6aa80f74af, or to the current HEAD of master as is done in the `Vendors` file.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pki-io/admin/146)

<!-- Reviewable:end -->
